### PR TITLE
normalize request path takes into account localhost

### DIFF
--- a/lib/proxyIntegration.js
+++ b/lib/proxyIntegration.js
@@ -108,7 +108,7 @@ function process(proxyIntegrationConfig, event, context) {
 }
 
 function normalizeRequestPath(event) {
-	if (isLocalExecution(event)) {
+    if (isLocalExecution(event)) {
       return event.path;
     }
     
@@ -194,9 +194,9 @@ function extractPathNames(pathExpression) {
 }
 
 function isLocalExecution(event) {
-   return event.headers 
-   	   && event.headers.Host
-   	   && event.headers.Host.startsWith('localhost');
+   return event.headers
+       && event.headers.Host
+       && event.headers.Host.startsWith('localhost');
 }
 
 module.exports = process;

--- a/lib/proxyIntegration.js
+++ b/lib/proxyIntegration.js
@@ -108,6 +108,10 @@ function process(proxyIntegrationConfig, event, context) {
 }
 
 function normalizeRequestPath(event) {
+	if (isLocalExecution(event)) {
+      return event.path;
+    }
+    
     // ugly hack: if host is from API-Gateway 'Custom Domain Name Mapping', then event.path has the value '/basepath/resource-path/';
     // if host is from amazonaws.com, then event.path is just '/resource-path':
     const apiId = event.requestContext ? event.requestContext.apiId : null; // the apiId that is the first part of the amazonaws.com-host
@@ -187,6 +191,12 @@ function extractPathNames(pathExpression) {
     const pathNameRegex = new RegExp('^' + pathExpression.replace(/:[\w.]+/g, ":([\\w]+)") + '$');
     const pathNames = pathNameRegex.exec(pathExpression);
     return pathNames && pathNames.length > 0 ? pathNames.slice(1) : null;
+}
+
+function isLocalExecution(event) {
+   return event.headers 
+   	   && event.headers.Host
+   	   && event.headers.Host.startsWith('localhost');
 }
 
 module.exports = process;

--- a/test/proxyIntegration.spec.js
+++ b/test/proxyIntegration.spec.js
@@ -221,28 +221,10 @@ describe('proxyIntegration.routeHandler', () => {
         }, context);
     });
     it('should not change path if not coming over custom domain name', () => {
-        const actionSpy = jasmine.createSpy('action');
-        const context = {};
-        const event = {
-            httpMethod: 'GET', path: "/123/456",
-            headers: {Host: "blabla.execute-api.eu-central-1.amazonaws.com"},
-            requestContext: {apiId: 'blabla'}
-        };
-        proxyIntegration({
-            routes: [{
-                method: 'GET',
-                path: '/123/456',
-                action: actionSpy
-            }]
-        }, event, context, () => {
-        });
-        expect(actionSpy).toHaveBeenCalledWith({
-            httpMethod: 'GET',
-            headers: jasmine.anything(),
-            requestContext: jasmine.anything(),
-            path: "/123/456",
-            paths: {}
-        }, context);
+        assertPathIsUnchanged("blabla.execute-api.eu-central-1.amazonaws.com");
+    });
+    it('should not change path if coming over localhost', () => {
+        assertPathIsUnchanged("localhost");
     });
     it('should return 400 for an invalid body', (done) => {
         proxyIntegration({routes: [{}]}, {httpMethod: 'GET', path: '/', body: '{keinJson'}).then(result => {
@@ -488,4 +470,29 @@ describe('proxyIntegration.routeHandler.returnvalues', () => {
         });
     });
 });
+
+function assertPathIsUnchanged(hostname) {
+    const actionSpy = jasmine.createSpy('action');
+    const context = {};
+    const event = {
+        httpMethod: 'GET', path: "/123/456",
+        headers: {Host: hostname},
+        requestContext: {apiId: 'blabla'}
+    };
+    proxyIntegration({
+        routes: [{
+            method: 'GET',
+            path: '/123/456',
+            action: actionSpy
+        }]
+    }, event, context, () => {
+    });
+    expect(actionSpy).toHaveBeenCalledWith({
+        httpMethod: 'GET',
+        headers: jasmine.anything(),
+        requestContext: jasmine.anything(),
+        path: "/123/456",
+        paths: {}
+    }, context);
+}
 


### PR DESCRIPTION
When using sam local the host is set to localhost.
In this case the path does not need to be normalized.

## Details
Without this change, the router removes the first part of the url path, i.e.
```
> curl -H 'Content-Type: application/json; Host: http://whatever' -X PUT -d '{"message" : "hello" }' http://localhost:3000/a/b/c
{"message":"Could not find matching action for /b/c and method PUT","error":"NO_MATCHING_ACTION"}
```
Basically `/a` was removed from the path.
## The fix
Check if the Host is localhost. In this case, just skip normalization.
