### PR TITLE
fixed yarn install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ npm install aws-lambda-router
 or yarn
 
 ```
-$ yarn install aws-lambda-router
+$ yarn add aws-lambda-router
 ```
 
 ## Getting Started


### PR DESCRIPTION
`install` has been replaced with `add` to add new dependencies. Run "yarn add aws-lambda-router" instead.