### PR TITLE
ProxyResources. Adding new config: proxyPath 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ export interface ProxyIntegrationConfig {
     debug?: boolean;
     errorMapping?: any;
     defaultHeaders?: string;
+    proxyPath?: string;
 }
 
 export interface SnsRoute {

--- a/lib/proxyIntegration.js
+++ b/lib/proxyIntegration.js
@@ -80,7 +80,11 @@ function process(proxyIntegrationConfig, event, context) {
     const errorMapping = proxyIntegrationConfig.errorMapping || {};
     errorMapping['NO_MATCHING_ACTION'] = 404;
 
-    event.path = normalizeRequestPath(event);
+    if (proxyIntegrationConfig.proxyPath) {
+        event.path = event.pathParameters[proxyIntegrationConfig.proxyPath];
+    } else {
+        event.path = normalizeRequestPath(event);
+    }
 
     try {
         const actionConfig = findMatchingActionConfig(event.httpMethod, event.path, proxyIntegrationConfig) || {


### PR DESCRIPTION
Adding support for using event.pathParameters instead of regular path.

This allows the route to be written without the base part, so we can write the route like this:
`proxyIntegration: {
    proxyPath: 'proxy',
    routes: [
      {
        path: 'generate',
       ...`

In api gateway the resource should be defined like this:
`/somebasepath/{proxy+}`

I know there is already a workaround to fix this, but this is 