### PR TITLE
Allow defaultHeaders to be added to the OPTIONS request

### DIFF
--- a/lib/proxyIntegration.ts
+++ b/lib/proxyIntegration.ts
@@ -91,17 +91,19 @@ export const process: ProcessMethod<ProxyIntegrationConfig, APIGatewayProxyEvent
       return null
     }
 
+    const headers: APIGatewayProxyResult['headers'] = proxyIntegrationConfig.cors ? addCorsHeaders(proxyIntegrationConfig.cors, event) : {};
+    
     if (event.httpMethod === 'OPTIONS') {
+      Object.assign(headers, proxyIntegrationConfig.defaultHeaders)
       return Promise.resolve({
         statusCode: 200,
-        headers: proxyIntegrationConfig.cors ? addCorsHeaders(proxyIntegrationConfig.cors, event) : {},
+        headers,
         body: ''
       })
     }
 
-    const headers: APIGatewayProxyResult['headers'] = proxyIntegrationConfig.cors ? addCorsHeaders(proxyIntegrationConfig.cors, event) : {};
     Object.assign(headers, { 'Content-Type': 'application/json' }, proxyIntegrationConfig.defaultHeaders)
-
+    
     // assure necessary values have sane defaults:
     const errorMapping = proxyIntegrationConfig.errorMapping || {}
     errorMapping['NO_MATCHING_ACTION'] = 404

--- a/test/proxyIntegration.test.ts
+++ b/test/proxyIntegration.test.ts
@@ -330,6 +330,27 @@ describe('proxyIntegration.routeHandler', () => {
     })
   })
 
+  it('should return default headers to OPTIONS request without content-type', async () => {
+    const routeConfig: ProxyIntegrationConfig = {
+      defaultHeaders: { 'a': '1', 'b': '2' },
+      routes: [
+        {
+          method: 'OPTIONS',
+          path: '/',
+          action: () => ({}) as any
+        }
+      ]
+    }
+    const result = await proxyIntegration(routeConfig, {
+      path: '/',
+      httpMethod: 'OPTIONS'
+    } as APIGatewayProxyEvent, context)
+    expect(result).toEqual({
+      statusCode: 200,
+      headers: { 'a': '1', 'b': '2' },
+      body: ''
+    })
+  })
 
   it('should return error headers', async () => {
     const routeConfig = {


### PR DESCRIPTION
This PR will allow the headers specified in the `defaultHeaders` config object to be added to the `OPTIONS` request but will  not add the default `Content-Type` header to the OPTIONS (unless specified in the `defaultHeaders` object).  Again, this does not break backwards compatibility.