### PR TITLE
Fix logging statements that are always printed even when debug is not…

### DIFF
--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -18,7 +18,9 @@ export interface S3Config {
 const validateArguments = (s3Config: S3Config, event: S3Event) => {
 
   if (!Array.isArray(event.Records) || event.Records.length < 1 || event.Records[0].eventSource !== 'aws:s3') {
-    console.log('Event does not look like S3')
+    if (s3Config.debug) {
+      console.log('Event does not look like S3')
+    }
     return false
   }
 

--- a/lib/sns.ts
+++ b/lib/sns.ts
@@ -21,7 +21,9 @@ export const process: ProcessMethod<SnsConfig, SnsEvent, Context, any> = (snsCon
   }
 
   if (!Array.isArray(event.Records) || event.Records.length < 1 || !event.Records[0].Sns) {
-    console.log('Event does not look like SNS')
+    if(snsConfig.debug) {
+      console.log('Event does not look like SNS')
+    }
     return null
   }
 

--- a/lib/sqs.ts
+++ b/lib/sqs.ts
@@ -21,7 +21,9 @@ export const process: ProcessMethod<SqsConfig, SqsEvent, Context, any> = (sqsCon
   }
 
   if (!Array.isArray(event.Records) || event.Records.length < 1 || event.Records[0].eventSource !== 'aws:sqs') {
-    console.log('Event does not look like SQS')
+    if(sqsConfig.debug) {
+      console.log('Event does not look like SQS')
+    }
     return null
   }
 


### PR DESCRIPTION
… turned on.

If the router parses an SNS event, the SQS console log statement is printed. It ignores the config setting debug. So every SNS event would have this log statement.

This PR fixes that problem. 

Example:
![image](https://user-images.githubusercontent.com/3153814/106012605-db571400-60bb-11eb-9c53-d3f3fc959ef6.png)
