### PR TITLE
Adding generic errorHandler to proxyIntegration

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,10 @@ export interface RouteConfig {
   sqs?: SqsConfig
   s3?: S3Config
   debug?: boolean
+  onError?: ErrorHandler
 }
+
+export type ErrorHandler<TContext extends Context = Context> = (error?: Error, event?: RouterEvent, context?: TContext) => Promise<any> | any | void
 
 export type RouterEvent = ProxyIntegrationEvent | SnsEvent | SqsEvent | S3Event
 
@@ -46,6 +49,12 @@ export const handler = (routeConfig: RouteConfig) => {
       } catch (error) {
         if (error.stack) {
           console.log(error.stack)
+        }
+        if (routeConfig.onError) {
+          const result = await routeConfig.onError(error, event, context)
+          if (result) {
+            return result
+          }
         }
         throw error.toString()
       }

--- a/index.ts
+++ b/index.ts
@@ -66,7 +66,7 @@ export const handler = (routeConfig: RouteConfig) => {
 const extractEventProcessorMapping = (routeConfig: RouteConfig) => {
   const processorMap = new Map<string, EventProcessor>()
   for (const key of Object.keys(routeConfig)) {
-    if (key === 'debug') {
+    if (key === 'debug' || key === 'onError') {
       continue
     }
     try {


### PR DESCRIPTION
fixes #41 .Adding a generic error handler. The idéa is to have a place for handling error logging and also return custom error messages. Ex:

```
onError: (error, event, context) => {
    // Global exceptions goes here, works for sns, s3 and sqs should end up here aswell
    console.log(error)
},
proxyIntegration: {
    onError: (error, request, context) => {
        // proxy integration exceptions goes here
        console.log('Error', error, request, context)
    },
    routes: ...
}

// Also support returning a response:
proxyIntegration: {
    onError: async (error) => {
        console.log('Error', error)
        await someAsyncMethod();
        return {
           statusCode: 401,
           body: Not allowed
        }
    },
    routes: ...
}