### PR TITLE
fix: send cors headers back after onError result

### DIFF
--- a/lib/proxyIntegration.ts
+++ b/lib/proxyIntegration.ts
@@ -151,7 +151,7 @@ export const process: ProcessMethod<ProxyIntegrationConfig, APIGatewayProxyEvent
         if (proxyIntegrationConfig.onError) {
           const result = await proxyIntegrationConfig.onError(error, event, context)
           if (result != undefined) {
-            return result
+            return { headers, ...result }
           }
         }
 
@@ -164,7 +164,7 @@ export const process: ProcessMethod<ProxyIntegrationConfig, APIGatewayProxyEvent
           const promise = proxyIntegrationConfig.onError(error, event, context)
           Promise.resolve(promise).then(result => {
           if (result != undefined) {
-            return result
+            return { headers, ...result }
           }
 
           return convertError(error, errorMapping, headers)


### PR DESCRIPTION
`cors` would block the api from sending the result back after `proxyIntegrationConfig.onError` since the lib was returning the result without the headers. 

Before this PR, I was sending the headers by setting them manually and returning from `onError`. 

    