### PR TITLE
Added Flag to Disable Base Path Removal

### DIFF
--- a/lib/proxyIntegration.ts
+++ b/lib/proxyIntegration.ts
@@ -40,7 +40,8 @@ export type ProxyIntegrationError = {
 export interface ProxyIntegrationConfig {
   onError?: ErrorHandler
   cors?: CorsOptions | boolean
-  routes: ProxyIntegrationRoute[]
+  routes: ProxyIntegrationRoute[],
+  removeBasePath?: boolean,
   debug?: boolean
   errorMapping?: ProxyIntegrationErrorMapping
   defaultHeaders?: APIGatewayProxyResult['headers']
@@ -183,7 +184,7 @@ const normalizeRequestPath = (event: APIGatewayProxyEvent): string => {
   // ugly hack: if host is from API-Gateway 'Custom Domain Name Mapping', then event.path has the value '/basepath/resource-path/'
   // if host is from amazonaws.com, then event.path is just '/resource-path':
   const apiId = event.requestContext ? event.requestContext.apiId : null // the apiId that is the first part of the amazonaws.com-host
-  if ((apiId && event.headers && event.headers.Host && event.headers.Host.substring(0, apiId.length) !== apiId)) {
+  if ((apiId && event.headers && event.headers.Host && event.headers.Host.substring(0, apiId.length) !== apiId) && (proxyIntegrationConfig.removeBasePath === undefined || proxyIntegrationConfig.removeBasePath)) {
     // remove first path element:
     const groups = /\/[^\/]+(.*)/.exec(event.path) || [null, null]
     return groups[1] || '/'

--- a/lib/proxyIntegration.ts
+++ b/lib/proxyIntegration.ts
@@ -120,7 +120,7 @@ export const process: ProcessMethod<ProxyIntegrationConfig, APIGatewayProxyEvent
         console.log(`proxy path with event path: ${event.path}`)
       }
     } else {
-      event.path = normalizeRequestPath(event)
+      event.path = normalizeRequestPath(event, proxyIntegrationConfig.removeBasePath)
     }
 
     try {
@@ -162,8 +162,8 @@ export const process: ProcessMethod<ProxyIntegrationConfig, APIGatewayProxyEvent
       console.log('Error while evaluating matching action handler', error)
 
       if (proxyIntegrationConfig.onError) {
-          const promise = proxyIntegrationConfig.onError(error, event, context)
-          Promise.resolve(promise).then(result => {
+        const promise = proxyIntegrationConfig.onError(error, event, context)
+        Promise.resolve(promise).then(result => {
           if (result != undefined) {
             return { headers, ...result }
           }
@@ -176,15 +176,15 @@ export const process: ProcessMethod<ProxyIntegrationConfig, APIGatewayProxyEvent
     }
   }
 
-const normalizeRequestPath = (event: APIGatewayProxyEvent): string => {
+const normalizeRequestPath = (event: APIGatewayProxyEvent, removeBasePath: boolean = true): string => {
   if (isLocalExecution(event)) {
     return event.path
   }
-
   // ugly hack: if host is from API-Gateway 'Custom Domain Name Mapping', then event.path has the value '/basepath/resource-path/'
   // if host is from amazonaws.com, then event.path is just '/resource-path':
   const apiId = event.requestContext ? event.requestContext.apiId : null // the apiId that is the first part of the amazonaws.com-host
-  if ((apiId && event.headers && event.headers.Host && event.headers.Host.substring(0, apiId.length) !== apiId) && (proxyIntegrationConfig.removeBasePath === undefined || proxyIntegrationConfig.removeBasePath)) {
+  if ((apiId && event.headers && event.headers.Host && event.headers.Host.substring(0, apiId.length) !== apiId)
+    && removeBasePath) {
     // remove first path element:
     const groups = /\/[^\/]+(.*)/.exec(event.path) || [null, null]
     return groups[1] || '/'

--- a/test/proxyIntegration.test.ts
+++ b/test/proxyIntegration.test.ts
@@ -228,6 +228,25 @@ describe('proxyIntegration.routeHandler', () => {
       paths: {}
     }, context)
   })
+  it('should not remove basepath from root path if coming over custom domain name and removeBasePath is false', () => {
+    const actionSpy = jasmine.createSpy('action')
+    const event = {
+      httpMethod: 'GET', path: '/shortcut-itemsdev',
+      headers: { Host: 'api.ep.welt.de' },
+      requestContext: { apiId: 'blabla' }
+    }
+    proxyIntegration({
+      removeBasePath: false,
+      routes: [{
+        method: 'GET',
+        path: '/shortcut-itemsdev',
+        action: actionSpy
+      }]
+    }, event as any, context)
+    expect(actionSpy).toHaveBeenCalledWith({
+      httpMethod: 'GET', headers: jasmine.anything(), requestContext: jasmine.anything(), path: '/shortcut-itemsdev', routePath: '/shortcut-itemsdev', paths: {}
+    }, context)
+  })
   it('should not change path if not coming over custom domain name', async () => {
     await assertPathIsUnchanged('blabla.execute-api.eu-central-1.amazonaws.com')
   })


### PR DESCRIPTION
Added  property `removeBasePath` to `proxyIntegrationConfig` This will allow users to disable the default functionality of removing the `/basepath` from incoming requests when they have a custom domain.  If this looks okay I'll update documentation accordingly.