### PR TITLE
Add rawBody to ProxyIntegrationBody

### DIFF
--- a/lib/proxyIntegration.ts
+++ b/lib/proxyIntegration.ts
@@ -9,6 +9,7 @@ type ProxyIntegrationParams = {
 }
 
 type ProxyIntegrationBody<T = unknown> = {
+  rawBody?: T
   body: T
 }
 
@@ -137,6 +138,7 @@ export const process: ProcessMethod<ProxyIntegrationConfig, APIGatewayProxyEvent
       proxyEvent.routePath = actionConfig.routePath
       if (event.body) {
         try {
+          proxyEvent.rawBody = event.body
           proxyEvent.body = JSON.parse(event.body)
         } catch (parseError) {
           console.log(`Could not parse body as json: ${event.body}`, parseError)


### PR DESCRIPTION
Some applications need access to the original body data of a request, e.g. for the purposes of verifying digital signatures.  Along with the handy JSON-parsed version of the body, it would be useful to retain the raw body data for such purposes.